### PR TITLE
chore: disable emergency wrapper and default AI_REC_AUTO to 0

### DIFF
--- a/.agents/emergency.json
+++ b/.agents/emergency.json
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "rps": 0.3,
   "max_tokens": 2500,
   "retry": { "max": 8, "base_ms": 200, "max_ms": 10000 },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@
 - 참고: Start-Transcript 특성상 같은 PowerShell 세션에서 실행해야 전체 대화가 기록됩니다.
 
 #### 로컬 런처(권장)
-- `codex-session.ps1`: 코덱스 세션 자동 구성(루트 이동, UTF-8 설정, `AI_REC_AUTO=1`, 자동 녹화 시작)
-- `gemini-session.ps1`: 제미나이 세션 자동 구성(동일 동작, 에이전트 라벨만 다름)
+- `codex-session.ps1`: 코덱스 세션 자동 구성(루트 이동, UTF-8 설정, 기본 `AI_REC_AUTO=0`)
+- `gemini-session.ps1`: 제미나이 세션 자동 구성(동일 동작, 기본 `AI_REC_AUTO=0`)
 - 새 창으로 열기: `-Spawn` 스위치 지원. 예) `powershell -ExecutionPolicy Bypass -File .\\codex-session.ps1 -Spawn`
 - 현재 터미널에서 적용: `powershell -ExecutionPolicy Bypass -File .\\codex-session.ps1` 또는 `. .\\codex-session.ps1`
 

--- a/agents_hub/queue/codex_transcript_always_on.json
+++ b/agents_hub/queue/codex_transcript_always_on.json
@@ -4,9 +4,9 @@
   "title": "Always-on terminal transcript for agent sessions",
   "priority": "high",
   "tasks": [
-    "Default AI_REC_AUTO=1 when ACTIVE_AGENT present",
+    "Default AI_REC_AUTO=0 when ACTIVE_AGENT present",
     "Ensure claude.ps1 imports UTF-8 profile and starts transcript",
-    "Verify codex/gemini session launchers auto-record",
+    "Verify codex/gemini session launchers respect AI_REC_AUTO setting",
     "Document quick usage in AGENTS.md"
   ],
   "context": {

--- a/claude.ps1
+++ b/claude.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 try {
   $root = (Resolve-Path '.').Path
   $env:ACTIVE_AGENT = 'claude'
-  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '1' }
+  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '0' }
   . "$root\scripts\ps7_utf8_profile_sample.ps1"
 } catch {}
 

--- a/codex-session.ps1
+++ b/codex-session.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Start a Codex-labeled session with auto recording.
+  Start a Codex-labeled session (recording off by default).
 #>
 [CmdletBinding()]
 param([switch]$Spawn)

--- a/codex.ps1
+++ b/codex.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 try {
   $root = (Resolve-Path '.').Path
   $env:ACTIVE_AGENT = 'codex'
-  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '1' }
+  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '0' }
   . "$root\scripts\ps7_utf8_profile_sample.ps1"
 } catch {}
 

--- a/gemini-session.ps1
+++ b/gemini-session.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Start a Gemini-labeled session with auto recording.
+  Start a Gemini-labeled session (recording off by default).
 #>
 [CmdletBinding()]
 param([switch]$Spawn)

--- a/gemini.ps1
+++ b/gemini.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 try {
   $root = (Resolve-Path '.').Path
   $env:ACTIVE_AGENT = 'gemini'
-  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '1' }
+  if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '0' }
   . "$root\scripts\ps7_utf8_profile_sample.ps1"
 } catch {}
 

--- a/scripts/ps7_utf8_profile_sample.ps1
+++ b/scripts/ps7_utf8_profile_sample.ps1
@@ -75,8 +75,6 @@ function __Find-WorkspaceRoot {
 }
 
 try {
-  # Default AI_REC_AUTO=1 when an agent session is active and not explicitly disabled
-  if ((-not $env:AI_REC_AUTO) -and ($env:ACTIVE_AGENT -in @('codex','gemini','claude'))) { $env:AI_REC_AUTO = '1' }
   $auto = $env:AI_REC_AUTO
   if ($null -ne $auto -and $auto -ne '' -and $auto -ne '0') {
     $root = __Find-WorkspaceRoot

--- a/scripts/session_launcher.ps1
+++ b/scripts/session_launcher.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-  Launch or configure a workspace session with auto-recording and agent label.
+  Launch or configure a workspace session with optional recording and agent label.
 .DESCRIPTION
-  - Sets ACTIVE_AGENT and AI_REC_AUTO=1
-  - Moves to repo root and imports UTF-8 profile sample (which triggers ai-rec auto-start)
+  - Sets ACTIVE_AGENT and AI_REC_AUTO=0
+  - Moves to repo root and imports UTF-8 profile sample (ai-rec must be enabled separately)
   - Can optionally spawn a new PowerShell session (-Spawn)
 #>
 [CmdletBinding()]
@@ -26,16 +26,16 @@ if (-not (Test-Path $root)) { throw "Workspace root not found." }
 
 # Set environment and initialize
 $env:ACTIVE_AGENT = $Agent
-$env:AI_REC_AUTO = '1'
+$env:AI_REC_AUTO = '0'
 Set-Location $root
 
 # Import UTF-8 + auto-rec profile block (idempotent)
 . "$root\scripts\ps7_utf8_profile_sample.ps1"
 
-Write-Host "Session prepared: ROOT=$root, AGENT=$Agent, AI_REC_AUTO=1" -ForegroundColor Green
+Write-Host "Session prepared: ROOT=$root, AGENT=$Agent, AI_REC_AUTO=$($env:AI_REC_AUTO)" -ForegroundColor Green
 
 if ($Spawn) {
-  $cmd = "`$env:ACTIVE_AGENT='$Agent'; `$env:AI_REC_AUTO='1'; Set-Location '$root'; . .\scripts\ps7_utf8_profile_sample.ps1"
+  $cmd = "`$env:ACTIVE_AGENT='$Agent'; `$env:AI_REC_AUTO='0'; Set-Location '$root'; . .\scripts\ps7_utf8_profile_sample.ps1" 
   Start-Process -FilePath pwsh -ArgumentList @('-NoExit','-ExecutionPolicy','Bypass','-NoLogo','-Command', $cmd) -WorkingDirectory $root | Out-Null
 }
 

--- a/tools/claude_ui.ps1
+++ b/tools/claude_ui.ps1
@@ -17,7 +17,7 @@ Set-Location $root
 
 # Ensure agent label + auto transcript profile
 $env:ACTIVE_AGENT = 'claude'
-if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '1' }
+if (-not $env:AI_REC_AUTO) { $env:AI_REC_AUTO = '0' }
 . "$root\scripts\ps7_utf8_profile_sample.ps1"
 
 # Inject GROQ_API_KEY from repo secrets if not set; also set OpenAI-compatible envs for Groq


### PR DESCRIPTION
## Summary
- disable emergency Codex wrapper by default
- turn off AI_REC_AUTO in session launchers and agent wrappers
- clarify launcher defaults in docs and queue

## Testing
- `python -m invoke review` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pytest -q` *(fails: 15 failed, 11 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c8d5d99083299855d7cc022f07fb