### PR TITLE
feat: guard transcript to conversation cli

### DIFF
--- a/ai-rec-start.ps1
+++ b/ai-rec-start.ps1
@@ -20,6 +20,12 @@ function Get-ProjectRoot {
 }
 
 $root = Get-ProjectRoot
+
+# Restrict recording to conversation CLI sessions
+if (-not $env:ACTIVE_AGENT -or -not $env:ACTIVE_AGENT.Trim()) {
+  Write-Host "ACTIVE_AGENT not set; recording skipped." -ForegroundColor Yellow
+  return
+}
  $logDir = Join-Path $root "terminal_logs"
  if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir | Out-Null }
 

--- a/ai-rec-stop.ps1
+++ b/ai-rec-stop.ps1
@@ -5,6 +5,12 @@
 [CmdletBinding()]
 param()
 
+# Ensure stop is invoked only within a conversation CLI
+if (-not $env:ACTIVE_AGENT -or -not $env:ACTIVE_AGENT.Trim()) {
+  Write-Host "ACTIVE_AGENT not set; stop skipped." -ForegroundColor Yellow
+  return
+}
+
 try {
   Stop-Transcript | Out-Null
   $global:TRANSCRIPT_ACTIVE = $false

--- a/scripts/ps7_utf8_profile_extras.ps1
+++ b/scripts/ps7_utf8_profile_extras.ps1
@@ -16,11 +16,13 @@ function __Find-WorkspaceRoot {
 
 try {
   $auto = $env:AI_REC_AUTO
-  if ($null -ne $auto -and $auto -ne '' -and $auto -ne '0') {
-    $root = __Find-WorkspaceRoot
-    $recStart = Join-Path $root 'ai-rec-start.ps1'
-    if (Test-Path $recStart) {
-      & $recStart -FallbackRoot $root
+  if ($null -ne $auto -and $auto -ne '' -and $auto -ne '0' -and $env:ACTIVE_AGENT) {
+    if (-not $global:TRANSCRIPT_ACTIVE) {
+      $root = __Find-WorkspaceRoot
+      $recStart = Join-Path $root 'ai-rec-start.ps1'
+      if (Test-Path $recStart) {
+        & $recStart -FallbackRoot $root
+      }
     }
   }
 } catch { }


### PR DESCRIPTION
## Summary
- restrict transcript start/stop scripts to conversation CLI sessions
- avoid starting a new transcript when one is already active

## Testing
- `pytest` *(fails: AssertionError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf71bdb8832983babc6f2d736f6b