### PR TITLE
feat: add minimal ai cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 - 의존성 설치: `venv\Scripts\pip.exe install -r requirements.txt`
 - 시스템 시작: `venv\Scripts\python.exe -m invoke start`
 
+## AI CLI
+- `ai` : 인터랙티브 모드 시작
+  - `/exit` 종료
+  - `/p <provider>` 제공자 전환(예: claude, gemini)
+  - `/save` 대화 내용 저장
+- `ai "프롬프트"` : 원샷 질의
+
 ## 에이전트 전환/상태
 - 상태 확인: `invoke agent.status`
 - 전환: `invoke agent.set --name gemini|codex`

--- a/scripts/ai.py
+++ b/scripts/ai.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Simple multi-provider chat CLI.
+
+Usage:
+    ai                 # interactive mode
+    ai "prompt"        # one-shot query
+
+Interactive commands:
+    /exit              # exit session
+    /p <provider>      # switch provider (e.g. claude, gemini)
+    /save              # save transcript to file
+
+Currently provider calls are mocked and simply echo back the prompt
+with the provider tag. This keeps the CLI usable without requiring
+network access or API keys.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+DEFAULT_PROVIDER = "claude"
+
+TranscriptEntry = Tuple[str, str, str]  # provider, prompt, response
+
+
+def call_provider(provider: str, prompt: str) -> str:
+    """Return a pseudo response for the given provider.
+
+    Real provider integrations can replace this logic. For now, the
+    prompt is echoed back to keep the CLI self-contained.
+    """
+    return f"[{provider}] {prompt}"
+
+
+def one_shot(provider: str, prompt: str) -> List[TranscriptEntry]:
+    response = call_provider(provider, prompt)
+    print(response)
+    return [(provider, prompt, response)]
+
+
+def interactive(provider: str) -> List[TranscriptEntry]:
+    transcript: List[TranscriptEntry] = []
+    current = provider
+    while True:
+        try:
+            line = input("> ").strip()
+        except EOFError:
+            break
+        if not line:
+            continue
+        if line == "/exit":
+            break
+        if line.startswith("/p "):
+            current = line.split(maxsplit=1)[1].strip() or current
+            print(f"[system] provider set to {current}")
+            continue
+        if line == "/save":
+            save_transcript(transcript)
+            continue
+        response = call_provider(current, line)
+        print(response)
+        transcript.append((current, line, response))
+    return transcript
+
+
+def save_transcript(entries: List[TranscriptEntry]) -> Path | None:
+    if not entries:
+        print("[system] nothing to save")
+        return None
+    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    path = Path(f"ai_session_{ts}.txt")
+    with path.open("w", encoding="utf-8") as f:
+        for provider, prompt, response in entries:
+            f.write(f"provider: {provider}\n")
+            f.write(f"user: {prompt}\n")
+            f.write(f"assistant: {response}\n\n")
+    print(f"[system] transcript saved to {path}")
+    return path
+
+
+def main() -> None:
+    provider = DEFAULT_PROVIDER
+    if len(sys.argv) > 1:
+        prompt = " ".join(sys.argv[1:])
+        one_shot(provider, prompt)
+    else:
+        interactive(provider)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple `ai` CLI for interactive or one-shot queries with `/exit`, `/p`, and `/save`
- document new CLI usage in README

## Testing
- `pytest` (fails: Commands Overview not shown; organizer classification mismatch; missing docs; file agent rule tests fail; web agent tests fail)


------
https://chatgpt.com/codex/tasks/task_e_68a1d1f7e27883298ba5ba110f4fa1f2