### PR TITLE
feat(ai): persist provider selection

### DIFF
--- a/.agents/config.json
+++ b/.agents/config.json
@@ -2,5 +2,6 @@
   "hooks": {
     "enabled": false,
     "diff_confirm": true
-  }
+  },
+  "provider": "claude"
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## AI CLI
 - `ai` : 인터랙티브 모드 시작
   - `/exit` 종료
-  - `/p <provider>` 제공자 전환(예: claude, gemini)
+  - `/p <provider>` 제공자 전환(예: claude, gemini); 마지막 선택은 `.agents/config.json`에 저장되어 세션 간 유지됨
   - `/save` 대화 내용 저장
 - `ai "프롬프트"` : 원샷 질의
 

--- a/scripts/ai.py
+++ b/scripts/ai.py
@@ -23,6 +23,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
 
+from scripts.agent_manager import get_flag, set_flag
+
 DEFAULT_PROVIDER = "claude"
 
 TranscriptEntry = Tuple[str, str, str]  # provider, prompt, response
@@ -57,6 +59,7 @@ def interactive(provider: str) -> List[TranscriptEntry]:
             break
         if line.startswith("/p "):
             current = line.split(maxsplit=1)[1].strip() or current
+            set_flag("provider", current)
             print(f"[system] provider set to {current}")
             continue
         if line == "/save":
@@ -84,7 +87,7 @@ def save_transcript(entries: List[TranscriptEntry]) -> Path | None:
 
 
 def main() -> None:
-    provider = DEFAULT_PROVIDER
+    provider = get_flag("provider", DEFAULT_PROVIDER)
     if len(sys.argv) > 1:
         prompt = " ".join(sys.argv[1:])
         one_shot(provider, prompt)

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -1,0 +1,48 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from scripts import ai, agent_manager
+
+
+def patch_config(monkeypatch, tmp_path):
+    config_dir = tmp_path
+    config_path = config_dir / "config.json"
+    monkeypatch.setattr(agent_manager, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(agent_manager, "CONFIG_PATH", config_path)
+    return config_path
+
+
+def test_interactive_updates_provider(monkeypatch, tmp_path):
+    config_path = patch_config(monkeypatch, tmp_path)
+
+    inputs = iter(["/p gemini", "/exit"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    ai.interactive("claude")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["provider"] == "gemini"
+
+
+def test_main_reads_provider(monkeypatch, tmp_path):
+    config_path = patch_config(monkeypatch, tmp_path)
+    config_path.write_text(json.dumps({"provider": "gemini"}), encoding="utf-8")
+
+    captured = {}
+
+    def fake_interactive(provider):
+        captured["provider"] = provider
+        return []
+
+    monkeypatch.setattr(ai, "interactive", fake_interactive)
+    monkeypatch.setattr(sys, "argv", ["ai"])
+
+    ai.main()
+
+    assert captured["provider"] == "gemini"


### PR DESCRIPTION
## Summary
- remember last AI provider in `.agents/config.json`
- update `ai` CLI to load and save provider changes
- document provider persistence and add tests

## Testing
- `pytest tests/test_ai_provider.py -q`
- `pytest` *(fails: Getting Started section missing and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d416a5c0832982fa6dcd59e38f41