### PR TITLE
feat: log session TLDR with locking

### DIFF
--- a/scripts/session_logger.py
+++ b/scripts/session_logger.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import os
+
+if os.name == "nt":  # pragma: no cover - tested via interface
+    import msvcrt
+    _LOCK_SIZE = 0x7FFFFFFF
+
+    def _lock_file(f):
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, _LOCK_SIZE)
+
+    def _unlock_file(f):
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, _LOCK_SIZE)
+else:  # POSIX
+    import fcntl
+
+    def _lock_file(f):
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+
+    def _unlock_file(f):
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_DIR = ROOT / "docs" / "sessions"
+
+
+def append_session_tldr(summary: str, *, when: datetime | None = None, root: Path | None = None) -> Path:
+    """Append a session TL;DR to the daily markdown file.
+
+    Parameters
+    ----------
+    summary: str
+        Three-line summary text.
+    when: datetime | None
+        Timestamp for the entry; defaults to ``datetime.now()``.
+    root: Path | None
+        Repository root; mainly for testing.
+    Returns
+    -------
+    Path
+        Path to the file written.
+    """
+
+    when = when or datetime.now()
+    root = Path(root) if root is not None else ROOT
+    day_file = root / "docs" / "sessions" / f"{when:%Y-%m-%d}.md"
+    day_file.parent.mkdir(parents=True, exist_ok=True)
+    entry = f"### {when:%H:%M:%S}\n{summary.rstrip()}\n\n"
+    with open(day_file, "a", encoding="utf-8") as f:
+        _lock_file(f)
+        try:
+            f.write(entry)
+            f.flush()
+        finally:
+            _unlock_file(f)
+    return day_file

--- a/src/cli/ai_session.py
+++ b/src/cli/ai_session.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Iterable, List, Tuple
 
 from scripts.agent_manager import get_flag, set_flag
+from scripts.session_logger import append_session_tldr
 
 ROOT = Path(__file__).resolve().parents[2]
 TRANSCRIPT_START = ROOT / "ai-rec-start.ps1"
@@ -120,6 +121,7 @@ def interactive(provider: str, log_summary: bool) -> None:
             transcript.append((current, line, resp))
         summary = summarize_session(transcript)
         print("[summary]\n" + summary)
+        append_session_tldr(summary)
         if log_summary:
             append_messages_log(summary, current)
     finally:
@@ -137,6 +139,7 @@ def one_shot(provider: str, prompt: str, log_summary: bool) -> None:
         resp = "".join(parts).strip()
         summary = summarize_session([(provider, prompt, resp)])
         print("[summary]\n" + summary)
+        append_session_tldr(summary)
         if log_summary:
             append_messages_log(summary, provider)
     finally:

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+import multiprocessing as mp
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.session_logger import append_session_tldr
+
+
+def _worker(root: Path, text: str, when: datetime) -> None:
+    append_session_tldr(text, when=when, root=root)
+
+
+def test_concurrent_appends(tmp_path: Path) -> None:
+    when = datetime(2025, 1, 1, 10, 0, 0)
+    args = [
+        (tmp_path, "1\n2\n3", when),
+        (tmp_path, "4\n5\n6", when + timedelta(minutes=1)),
+    ]
+    with mp.Pool(2) as pool:
+        pool.starmap(_worker, args)
+    day_file = tmp_path / "docs" / "sessions" / "2025-01-01.md"
+    content = day_file.read_text(encoding="utf-8")
+    assert "1\n2\n3" in content
+    assert "4\n5\n6" in content


### PR DESCRIPTION
## Summary
- record session TLDRs in docs/sessions/DATE.md using file locks
- integrate session logger into ai_session CLI
- test concurrent appends to ensure summaries are preserved

## Testing
- `pytest tests/test_session_logger.py -q`
- `pytest -q` *(fails: Commands Overview assertion and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d89f80ec832982bcd746b48a6aac