### PR TITLE
feat: add emergency hook bypass and rollback docs

### DIFF
--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -2,6 +2,13 @@
 
 \*Last Updated: 2025-08-17
 
+## Rollback Steps
+
+1. Set `AGENTS_SKIP_HOOKS=1` to bypass malfunctioning automation hooks.
+2. Alternatively edit `.agents/config.json` and set `"hooks": {"enabled": false}`.
+3. After the issue is resolved, remove the env var or re-enable hooks in the config.
+4. To undo a bad commit, run `git reset --hard HEAD~1`.
+
 ## Projects
 
 ## Project Blueprints

--- a/scripts/hooks/precommit_diff_confirm.py
+++ b/scripts/hooks/precommit_diff_confirm.py
@@ -12,6 +12,9 @@ def run(args: list[str]) -> subprocess.CompletedProcess:
 
 
 def main():
+    # Allow emergency bypass of all automation hooks
+    if os.getenv("AGENTS_SKIP_HOOKS") in {"1", "true", "True"}:
+        sys.exit(0)
     # Skip in CI or when explicitly disabled or config flag off
     if os.getenv("SKIP_DIFF_CONFIRM") in {"1", "true", "True"}:
         sys.exit(0)

--- a/scripts/hooks/precommit_secrets_guard.py
+++ b/scripts/hooks/precommit_secrets_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -8,6 +9,9 @@ import json
 
 
 def main():
+    # Allow emergency bypass of all automation hooks
+    if os.getenv("AGENTS_SKIP_HOOKS") in {"1", "true", "True"}:
+        sys.exit(0)
     # Global toggle from .agents/config.json (hooks.enabled=false)
     try:
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- allow automation hooks to be bypassed via `AGENTS_SKIP_HOOKS` environment variable
- document rollback steps and hook bypass in HUB guide

## Testing
- `pytest` *(fails: tests/test_help_system.py::test_invoke_help, tests/test_organizer.py::test_classification_logic, tests/test_organizer.py::test_idempotency_and_move_plan, tests/test_p0_rules.py::test_debug_19_doc_exists, tests/test_p1_file_agent.py::test_list_rules, tests/test_p1_file_agent.py::test_explain_rule, tests/test_p1_file_agent.py::test_dry_run_does_not_modify_file, tests/test_p1_file_agent.py::test_apply_modifies_file, tests/test_p1_file_agent.py::test_idempotency, tests/test_p1_file_agent.py::test_unknown_rule_fails_gracefully, tests/test_p1_file_agent.py::test_boundary_check_fails_for_outside_path, tests/test_p1_file_agent.py::test_syntax_error_in_file_fails_gracefully, tests/test_p1_web_tool.py::test_web_agent_with_mocked_search, tests/test_p1_web_tool.py::test_invoke_search_task, tests/test_ux_enhancements.py::test_invoke_help_getting_started)`

------
https://chatgpt.com/codex/tasks/task_e_68a1e1f7bb708329aa837040d17535e9